### PR TITLE
Handle DevStack service catalog correctly

### DIFF
--- a/capi_janitor/openstack/openstack.py
+++ b/capi_janitor/openstack/openstack.py
@@ -22,6 +22,13 @@ class AuthenticationError(Exception):
     def __init__(self, user):
         super().__init__(f"failed to authenticate as user: {user}")
 
+class CatalogError(Exception):
+    """
+    Raised when an unknown catalog service type is requested.
+    """
+    def __init__(self, name):
+        super().__init__(f"service type {name} not found in OpenStack service catalog")
+
 
 class Auth(httpx.Auth):
     """

--- a/capi_janitor/openstack/openstack.py
+++ b/capi_janitor/openstack/openstack.py
@@ -128,13 +128,17 @@ class Client(rest.AsyncClient):
     Client for OpenStack APIs.
     """
     def __init__(self, /, base_url, prefix = None, **kwargs):
-        # Extract the path part of the base_url
+        # Extract the path part of the base_url
         url = urllib.parse.urlsplit(base_url)
         # Initialise the client with the scheme/host
         super().__init__(base_url = f"{url.scheme}://{url.netloc}", **kwargs)
-        # If another prefix is not given, use the path from the base URL as the prefix
+        # If another prefix is not given, use the path from the base URL as the prefix,
+        # otherwise combine the prefixes and remove duplicates path sections.
         # This ensures things like pagination work nicely without duplicating the prefix
-        self._prefix = prefix or url.path
+        if prefix:
+            self._prefix = "/".join([url.path.rstrip("/"), prefix.lstrip("/").lstrip(url.path)])
+        else:
+            self._prefix = url.path
 
     def __aenter__(self):
         # Prevent individual clients from being used in a context manager


### PR DESCRIPTION
Fixes a bug seen when running in a DevStack environment where OpenStack service catalog uses URL prefixes to expose each service.

Upon deleting a CAPI cluster inside DevStack, the current code raises errors such as:
```
httpx.HTTPStatusError: Client error '404 Not Found' for url 'http://172.16.1.138:9696/v2.0/floatingips'
```
when the catalog entry is
```
  {
    "Name": "neutron",
    "Type": "network",
    "Endpoints": [
      {
        "id": "eed217dcf8fe414dbd09ec7958e6f2ac",
        "interface": "public",
        "region_id": "RegionOne",
        "url": "http://172.16.1.138:9696/networking",
        "region": "RegionOne"
      }
    ]
  }
```
so the correct URL should be `http://172.16.1.138:9696/networking/v2.0/floatingips`.

Also handles the fact that Cinder service type is 'block-storage' in DevStack service catalog.