### PR TITLE
Allow operator to watch for CRD changes

### DIFF
--- a/chart/templates/clusterrole.yaml
+++ b/chart/templates/clusterrole.yaml
@@ -37,3 +37,12 @@ rules:
       - get
       - watch
       - patch
+    # Required to prevent erroneous error logs during kopf startup
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - list
+      - get
+      - watch


### PR DESCRIPTION
Required to prevent erroneous error logs during kopf startup such as:
```
kopf._cogs.clients.w [ERROR   ] Request attempt #1/9 failed; will retry: GET https://kubernetes.default.svc/apis/apiextensions.k8s.io/v1/customresourcedefinitions -> APIForbiddenError('customresourcedefinitions.apiextensions.k8s.io is forbidden: User "system:serviceaccount:capi-janitor:capi-janitor-cluster-api-janitor-openstack" cannot list resource "customresourcedefinitions" in API group "apiextensions.k8s.io" at the cluster scope', {'kind': 'Status', 'apiVersion': 'v1', 'metadata': {}, 'status': 'Failure', 'message': 'customresourcedefinitions.apiextensions.k8s.io is forbidden: User "system:serviceaccount:capi-janitor:capi-janitor-cluster-api-janitor-openstack" cannot list resource "customresourcedefinitions" in API group "apiextensions.k8s.io" at the cluster scope', 'reason': 'Forbidden', 'details': {'group': 'apiextensions.k8s.io', 'kind': 'customresourcedefinitions'}, 'code': 403})
```