### PR TITLE
Fix missing function await

### DIFF
--- a/capi_janitor/openstack/operator.py
+++ b/capi_janitor/openstack/operator.py
@@ -349,7 +349,7 @@ def retry_event(handler):
 async def on_openstackcluster_event(
     name, namespace, meta, labels, spec, logger, **kwargs
 ):
-    _on_openstackcluster_event_impl(
+    await _on_openstackcluster_event_impl(
         name, namespace, meta, labels, spec, logger, **kwargs
     )
 


### PR DESCRIPTION
Operator was logging the following on startup:
```
/venv/lib/python3.10/site-packages/capi_janitor/openstack/operator.py:352: RuntimeWarning: coroutine '_on_openstackcluster_event_impl' was never awaited
  _on_openstackcluster_event_impl(
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
```